### PR TITLE
Harden session handling in auth module

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,5 +1,10 @@
 <?php
 // auth.php - Enhanced Authentication functions with roles
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'),
+    'samesite' => 'Strict'
+]);
 session_start();
 require_once 'config.php';
 
@@ -88,6 +93,7 @@ function login($username, $password) {
     if ($stmt->rowCount() > 0) {
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if (password_verify($password, $row['password'])) {
+            session_regenerate_id(true);
             $_SESSION['user_id'] = $row['id'];
             $_SESSION['username'] = $row['username'];
             $_SESSION['role'] = $row['role'];


### PR DESCRIPTION
## Summary
- Ensure session cookies are sent with HttpOnly, Secure, and SameSite flags before starting sessions.
- Regenerate session ID after successful login to mitigate fixation attacks.

## Testing
- `php -l auth.php`


------
https://chatgpt.com/codex/tasks/task_b_6894153441f8832693ea25855b0913e3